### PR TITLE
Updated tech level for spacer start to use Spacer definition

### DIFF
--- a/1.3/Defs/FactionDefs/Factions_Bitbyte.xml
+++ b/1.3/Defs/FactionDefs/Factions_Bitbyte.xml
@@ -9,7 +9,7 @@
         <basicMemberKind>Colonist</basicMemberKind>
         <pawnSingular>colonist</pawnSingular>
         <pawnsPlural>colonists</pawnsPlural>
-        <techLevel>Industrial</techLevel>
+        <techLevel>Spacer</techLevel>
         <factionNameMaker>NamerFactionOutlander</factionNameMaker>
         <settlementNameMaker>NamerSettlementOutlander</settlementNameMaker>
         <allowedCultures>


### PR DESCRIPTION
Love the mod but realized the tech level was still set to Industrial. I don't know if this was intended or not, but I tested locally and this def works for allowing full research speed on all tiers.